### PR TITLE
Algsets urls can now contain their name

### DIFF
--- a/client/src/components/AlgSet/AlgSet.js
+++ b/client/src/components/AlgSet/AlgSet.js
@@ -87,7 +87,7 @@ const AlgSet = ({ match }) => (
                   </ImportExportDialog>
                 </Fragment>
               )}
-              <CopyToClipboard text={window.location}>
+              <CopyToClipboard text={`${window.location.host}/alg-sets/${algSet.id}/${algSet.name}`}>
                 <IconButton>
                   <Icon>link</Icon>
                 </IconButton>

--- a/client/src/components/Navigation/Navigation.js
+++ b/client/src/components/Navigation/Navigation.js
@@ -129,6 +129,7 @@ const Navigation = () => {
                   <Route path="/explore" component={Explore} />
                   <Route exact path="/alg-sets" component={AlgSetList} />
                   <Route exact path="/alg-sets/:id" component={AlgSet} />
+                  <Route exact path="/alg-sets/:id/:name" component={AlgSet} />
                   <Route exact path="/starred" component={StarredAlgSetList} />
                   <Redirect to="/alg-sets" />
                 </Switch>
@@ -137,6 +138,7 @@ const Navigation = () => {
                   <Route exact path="/" component={Home} />
                   <Route path="/explore" component={Explore} />
                   <Route exact path="/alg-sets/:id" component={AlgSet} />
+                  <Route exact path="/alg-sets/:id/:name" component={AlgSet} />
                   <Redirect to="/" />
                 </Switch>
               )}


### PR DESCRIPTION
Instead of https://algsets.jonatanklosko.com/alg-sets/5c71790f1a3b515e307eeab5, the url can be https://algsets.jonatanklosko.com/alg-sets/5c71790f1a3b515e307eeab5/winter-variation.

This enables the ability to share an algset without having to explain the url.

I've edited the navigation file to include the paths necessary and modified the copy url to include the name in the url. I deem this is all that is needed?